### PR TITLE
fix: 사이드바가 다른 컴포넌트 아래에 뜨는 현상 수정

### DIFF
--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -11,6 +11,7 @@ import ButtonSidebar from "./ButtonSidebar";
 import "./Sidebar/Sidebar.css";
 
 const TopBarPink = styled.div`
+  z-index: 5;
   margin: 0;
   background-color: var(--main-pink);
   width: 100%;


### PR DESCRIPTION
## 💡 이슈

resolve #58

## 📚 개요

사이드바를 열었을 때 페이지 타이틀을 비롯하여 가려져야할 컴포넌트들이 사이드바 위에 중첩되는 현상 발생
→ 수정

## 👩🏻‍💻 작업사항

사이드바의 부모 컴포넌트인 TopBar의 z-index 값을 수정하여 해결

## 💫 추가 코멘트


