### PR TITLE
PageTitle 컴포넌트 내부 styled component 선언 오류해결

### DIFF
--- a/src/components/PageTitle.js
+++ b/src/components/PageTitle.js
@@ -1,40 +1,39 @@
 import styled from "styled-components";
 
+const PageTitleBox = styled.div`
+  display: flex;
+  justify-content: center;
+
+  margin: ${props => props.margin};
+`;
+
+const Highlight = styled.div`
+  display: inline-block;
+
+  height: 13px;
+  background-color: var(--sub-pink);
+  vertical-align: center;
+`;
+
+const TitleText = styled.div`
+  width: fit-content;
+
+  margin: 0 3px;
+  position: relative;
+  bottom: 9px;
+
+  font-style: normal;
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 26px;
+  text-align: center;
+
+  color: var(—black-text);
+`;
+
 const PageTitle = ({ title, margin }) => {
-  const PageTitleBox = styled.div`
-    display: flex;
-    justify-content: center;
-
-    margin: ${margin};
-  `;
-
-  const Highlight = styled.div`
-    display: inline-block;
-
-    height: 13px;
-    background-color: var(--sub-pink);
-    vertical-align: center;
-  `;
-
-  const TitleText = styled.div`
-    width: fit-content;
-
-    margin: 0 3px;
-    position: relative;
-    bottom: 9px;
-
-    font-family: "Apple SD Gothic Neo";
-    font-style: normal;
-    font-weight: 700;
-    font-size: 22px;
-    line-height: 26px;
-    text-align: center;
-
-    color: var(--black-text);
-  `;
-
   return (
-    <PageTitleBox>
+    <PageTitleBox margin={margin}>
       <Highlight>
         <TitleText>{title}</TitleText>
       </Highlight>


### PR DESCRIPTION
## 💡 이슈

<img width="592" alt="스크린샷 2022-07-20 오전 12 45 23" src="https://user-images.githubusercontent.com/60884877/179793957-a6af1b9a-664b-44fc-be78-e8e7816ab8ea.png">
PageTilte 컴포넌트 사용하면 위와같은 경고가 리렌더링 될 때 마다 계속 뜸
→ 함수 컴포넌트 내부에서 styled component를 선언하면 생기는 경고문

## 📚 개요

어떤 작업인지 간단하게 작성해주세요.

## 👩🏻‍💻 작업사항

styled component 선언 위치 함수형 컴포넌트 외부로 옮기고
margin값의 경우 그대로 해당 styled component의 props로 사용할 수 있도록 설정
→ **PageTitle 컴포넌트를 사용하는 곳에서 변경해 주어야 하는 것 없음**

## 💫 추가 코멘트

- 그 외 추가적인 코멘트가 있을 경우 작성해주세요.
