### PR TITLE
카카오 로그인 토큰 비어있는 채로 요청 보내지던 현상 수정

### DIFF
--- a/src/common/http.js
+++ b/src/common/http.js
@@ -4,9 +4,13 @@ const token = JSON.parse(localStorage.getItem("token"));
 
 console.log("토큰", token);
 
-export default axios.create({
-  baseURL: "https://caker.shop/",
-  headers: {
-    "X-AUTH-TOKEN": token,
-  },
-});
+export default token
+  ? axios.create({
+      baseURL: "https://caker.shop/",
+      headers: {
+        "X-AUTH-TOKEN": token,
+      },
+    })
+  : axios.create({
+      baseURL: "https://caker.shop/",
+    });

--- a/src/components/HomeCardDisplay/Card.js
+++ b/src/components/HomeCardDisplay/Card.js
@@ -16,27 +16,27 @@ const SubTitle = styled.div`
   color: var(--main-pink);
   font-size: 14px;
 `;
+const ClientImg = styled.div`
+  background: url(${({ image }) => image});
+  width: 150.08px;
+  height: 114.11px;
+  background-repeat: no-repeat;
+  background-position: center center;
+  border-radius: 6px;
+`;
+const MockImg = styled.div`
+  background: url(${({ Mock }) => Mock});
+  width: 150.08px;
+  height: 114.11px;
+  background-repeat: no-repeat;
+  background-position: center center;
+  border-radius: 6px;
+`;
 
 const Card = ({ title, subtitle, image }) => {
-  const ClientImg = styled.div`
-    background: url(${image});
-    width: 150.08px;
-    height: 114.11px;
-    background-repeat: no-repeat;
-    background-position: center center;
-    border-radius: 6px;
-  `;
-  const MockImg = styled.div`
-    background: url(${Mock});
-    width: 150.08px;
-    height: 114.11px;
-    background-repeat: no-repeat;
-    background-position: center center;
-    border-radius: 6px;
-  `;
   return (
     <CardComponent>
-      {image ? <ClientImg></ClientImg> : <MockImg></MockImg>}
+      {image ? <ClientImg image={image} /> : <MockImg Mock={Mock} />}
 
       <Title>{title}</Title>
       <SubTitle>{subtitle}</SubTitle>

--- a/src/pages/Auth/LoginLoading.js
+++ b/src/pages/Auth/LoginLoading.js
@@ -5,30 +5,29 @@ import { useEffect } from "react";
 
 const LoginLoading = () => {
   const nav = useNavigate();
-
-  const token = new URL(document.location.toString()).searchParams.get("token");
+  const token = new URLSearchParams(location.search).get("token");
+  const firstLogin = new URLSearchParams(location.search).get("firstLogin");
   localStorage.setItem("token", JSON.stringify(token));
-
-  const firstLogin = new URL(document.location.toString()).searchParams.get(
-    "firstLogin",
-  );
-
-  AuthService.login(token)
-    .then(res => {
-      localStorage.setItem("user", JSON.stringify(res.data));
-      localStorage.setItem("isLogin", JSON.stringify("true"));
-    })
-    .catch(e => {
-      console.error(e, "로그인에 실패했습니다.");
-    });
-
-  setTimeout(() => {
-    if (firstLogin === "true") {
-      nav("/loginhome");
-    } else {
-      nav("/");
-    }
-  }, 2000);
+  useEffect(() => {
+    AuthService.login(token)
+      .then(res => {
+        localStorage.setItem("user", JSON.stringify(res.data));
+        localStorage.setItem("isLogin", JSON.stringify("true"));
+      })
+      .catch(e => {
+        console.error(e, "로그인에 실패했습니다.");
+      })
+      .finally(() => {
+        // 오류나도 일단 넘어가게
+        setTimeout(() => {
+          if (firstLogin === "true") {
+            nav("/loginhome");
+          } else {
+            nav("/");
+          }
+        }, 1000);
+      });
+  }, []);
 
   console.log("현재 유저", JSON.parse(localStorage.getItem("user")));
 


### PR DESCRIPTION
## 💡 이슈

resolve #{이슈번호}

## 📚 개요

로그인시 로딩화면에서 오류가 발생하던 것 수정하였습니다.

## 👩🏻‍💻 작업사항

localStroage에서 토큰값을 저장하고 이를 불러와서 다시 요청을 보내는 시점이 약간 어긋났던 것 같아 경우의 수 나눠서 헤더값 적용하도록 설정해봤습니다.

## 💫 추가 코멘트

- 그 외 추가적인 코멘트가 있을 경우 작성해주세요.
